### PR TITLE
encode + call authorizeOrder, reuse encoding for validateOrder

### DIFF
--- a/src/core/lib/BasicOrderFulfiller.sol
+++ b/src/core/lib/BasicOrderFulfiller.sol
@@ -1022,7 +1022,10 @@ contract BasicOrderFulfiller is OrderValidator {
         OrderStatus storage orderStatus = _validateBasicOrder(
             orderHash,
             _toBytesReturnType(_decodeBytes)(
-                CalldataPointer.wrap(CalldataPointer.wrap(BasicOrder_signature_cdPtr).readMaskedUint256())
+                CalldataPointer.wrap(
+                    CalldataPointer.wrap(BasicOrder_signature_cdPtr)
+                        .readMaskedUint256() + 0x24
+                )
             )
         );
 

--- a/src/core/lib/BasicOrderFulfiller.sol
+++ b/src/core/lib/BasicOrderFulfiller.sol
@@ -1022,7 +1022,7 @@ contract BasicOrderFulfiller is OrderValidator {
         OrderStatus storage orderStatus = _validateBasicOrder(
             orderHash,
             _toBytesReturnType(_decodeBytes)(
-                CalldataPointer.wrap(BasicOrder_signature_cdPtr)
+                CalldataPointer.wrap(CalldataPointer.wrap(BasicOrder_signature_cdPtr).readMaskedUint256())
             )
         );
 

--- a/src/core/lib/Consideration.sol
+++ b/src/core/lib/Consideration.sol
@@ -87,7 +87,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         to the documentation for a more comprehensive summary of how to
      *         utilize this method and what orders are compatible with it.
      *
-     * @param parameters Additional information on the fulfilled order. Note
+     * @custom:param parameters Additional information on the fulfilled order. Note
      *                   that the offerer and the fulfiller must first approve
      *                   this contract (or their chosen conduit if indicated)
      *                   before any tokens can be transferred. Also note that
@@ -97,14 +97,19 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      * @return fulfilled A boolean indicating whether the order has been
      *                   successfully fulfilled.
      */
-    function fulfillBasicOrder(BasicOrderParameters calldata parameters)
+    function fulfillBasicOrder(
+        /**
+         * @custom:name parameters
+         */
+        BasicOrderParameters calldata
+    )
         external
         payable
         override
         returns (bool fulfilled)
     {
         // Validate and fulfill the basic order.
-        fulfilled = _validateAndFulfillBasicOrder(parameters);
+        fulfilled = _validateAndFulfillBasicOrder();
     }
 
     /**
@@ -125,7 +130,7 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *         the zero bytes in the function selector (0x00000000) which also
      *         results in earlier function dispatch.
      *
-     * @param parameters Additional information on the fulfilled order. Note
+     * @custom:param parameters Additional information on the fulfilled order. Note
      *                   that the offerer and the fulfiller must first approve
      *                   this contract (or their chosen conduit if indicated)
      *                   before any tokens can be transferred. Also note that
@@ -136,10 +141,13 @@ contract Consideration is ConsiderationInterface, OrderCombiner {
      *                   successfully fulfilled.
      */
     function fulfillBasicOrder_efficient_6GL6yc(
-        BasicOrderParameters calldata parameters
+        /**
+         * @custom:name parameters
+         */
+        BasicOrderParameters calldata
     ) external payable override returns (bool fulfilled) {
         // Validate and fulfill the basic order.
-        fulfilled = _validateAndFulfillBasicOrder(parameters);
+        fulfilled = _validateAndFulfillBasicOrder();
     }
 
     /**

--- a/src/core/lib/ConsiderationDecoder.sol
+++ b/src/core/lib/ConsiderationDecoder.sol
@@ -1134,6 +1134,32 @@ contract ConsiderationDecoder {
     /**
      * @dev Converts a function taking a calldata pointer and returning a memory
      *      pointer into a function taking that calldata pointer and returning
+     *      a bytes type.
+     *
+     * @param inFn The input function, taking an arbitrary calldata pointer and
+     *             returning an arbitrary memory pointer.
+     *
+     * @return outFn The output function, taking an arbitrary calldata pointer
+     *               and returning a bytes type.
+     */
+    function _toBytesReturnType(
+        function(CalldataPointer) internal pure returns (MemoryPointer) inFn
+    )
+        internal
+        pure
+        returns (
+            function(CalldataPointer) internal pure returns (bytes memory)
+                outFn
+        )
+    {
+        assembly {
+            outFn := inFn
+        }
+    }
+
+    /**
+     * @dev Converts a function taking a calldata pointer and returning a memory
+     *      pointer into a function taking that calldata pointer and returning
      *      an OrderParameters type.
      *
      * @param inFn The input function, taking an arbitrary calldata pointer and

--- a/src/core/lib/ConsiderationEncoder.sol
+++ b/src/core/lib/ConsiderationEncoder.sol
@@ -543,21 +543,21 @@ contract ConsiderationEncoder {
      *
      * @param orderHash  The order hash.
      *
-     * @return dst  A memory pointer referencing the encoded `authorizeOrder`
-     *              calldata.
+     * @return ptr  A memory pointer referencing the encoded `authorizeOrder`
+     *              calldata with extra padding at the start to word align.
      * @return size The size of the bytes array.
      */
     function _encodeAuthorizeBasicOrder(
         bytes32 orderHash
     ) internal view returns (
-        MemoryPointer dst,
+        MemoryPointer ptr,
         uint256 size,
         uint256 memoryLocationForOrderHashes
     ) {
         // Get free memory pointer to write calldata to.
-        MemoryPointer ptr = getFreeMemoryPointer();
+        ptr = getFreeMemoryPointer();
 
-        dst = ptr;
+        MemoryPointer dst = ptr;
 
         // Write validateOrder selector and get pointer to start of calldata.
         dst.write(authorizeOrder_selector);
@@ -632,7 +632,7 @@ contract ConsiderationEncoder {
         // Write offset to orderHashes.
         dstHead.offset(ZoneParameters_orderHashes_head_offset).write(tailOffset);
 
-        memoryLocationForOrderHashes = dstHead.offset(tailOffset).readMaskedUint256();
+        memoryLocationForOrderHashes = MemoryPointer.unwrap(dstHead.offset(tailOffset));
 
         // Write length = 0 to the orderHashes array.
         dstHead.offset(tailOffset).write(0);
@@ -645,7 +645,7 @@ contract ConsiderationEncoder {
             size = ZoneParameters_basicOrderFixedElements_length + tailOffset;
 
             // Update the free memory pointer.
-            setFreeMemoryPointer(ptr.offset(size + OneWord));
+            setFreeMemoryPointer(dst.offset(size + OneWord));
         }
     }
 

--- a/src/core/lib/ConsiderationEncoder.sol
+++ b/src/core/lib/ConsiderationEncoder.sol
@@ -482,9 +482,9 @@ contract ConsiderationEncoder {
         // Track the pointer, size (when performing validateOrder) and pointer
         // to orderHashes length by overriding the salt value on the order.
         orderParameters.salt = (
-            (ptr.readMaskedUint256() << 128) &
-            (size << 64) &
-            orderHashesLengthLocation.readMaskedUint256()
+            (MemoryPointer.unwrap(ptr) << 128) |
+            (size << 64) |
+            MemoryPointer.unwrap(orderHashesLengthLocation)
         );
 
         // Write the shorted orderHashes array length.

--- a/src/core/lib/ConsiderationEncoder.sol
+++ b/src/core/lib/ConsiderationEncoder.sol
@@ -45,6 +45,7 @@ import {
     SpentItem_size_shift,
     SpentItem_size,
     validateOrder_selector,
+    validateOrder_selector_offset,
     ZoneParameters_base_tail_offset,
     ZoneParameters_basicOrderFixedElements_length,
     ZoneParameters_consideration_head_offset,
@@ -477,7 +478,7 @@ contract ConsiderationEncoder {
         }
 
         // Update the free memory pointer.
-        setFreeMemoryPointer(ptr.offset(size));
+        setFreeMemoryPointer(dst.offset(size));
 
         // Track the pointer, size (when performing validateOrder) and pointer
         // to orderHashes length by overriding the salt value on the order.
@@ -525,6 +526,8 @@ contract ConsiderationEncoder {
 
         // Write validateOrder selector.
         dst.write(validateOrder_selector);
+
+        dst = dst.offset(validateOrder_selector_offset);
 
         // Encode the order hashes array. Note that this currently modifies
         // order hashes that are known to be properly encoded already and could

--- a/src/core/lib/OrderCombiner.sol
+++ b/src/core/lib/OrderCombiner.sol
@@ -486,7 +486,9 @@ contract OrderCombiner is OrderFulfiller, FulfillmentApplier {
 
                 // Update order status as long as there is some fraction available.
                 if (advancedOrder.parameters.orderType != OrderType.CONTRACT) {
-                    // TODO: perform authorizeOrder call
+                    _assertRestrictedAdvancedOrderAuthorization(
+                        advancedOrder, orderHashes, orderHash, (i / OneWord) - 1
+                    );
 
                     if (!_updateStatus(
                         orderHash,

--- a/src/core/lib/OrderFulfiller.sol
+++ b/src/core/lib/OrderFulfiller.sol
@@ -121,7 +121,6 @@ contract OrderFulfiller is
 
         // Declare empty bytes32 array and populate with the order hash.
         bytes32[] memory orderHashes = new bytes32[](1);
-        orderHashes[0] = orderHash;
 
         if (advancedOrder.parameters.orderType != OrderType.CONTRACT) {
             _assertRestrictedAdvancedOrderAuthorization(
@@ -194,6 +193,8 @@ contract OrderFulfiller is
         }
 
         _transferEach(orderParameters, fulfillerConduitKey);
+
+        orderHashes[0] = orderHash;
 
         // Ensure restricted orders have a valid submitter or pass a zone check.
         _assertRestrictedAdvancedOrderValidity(

--- a/src/core/lib/OrderFulfiller.sol
+++ b/src/core/lib/OrderFulfiller.sol
@@ -121,9 +121,11 @@ contract OrderFulfiller is
 
         bytes32[] memory orderHashes = new bytes32[](0);
 
-        // TODO: perform authorizeOrder call here
-
         if (advancedOrder.parameters.orderType != OrderType.CONTRACT) {
+            _assertRestrictedAdvancedOrderAuthorization(
+                advancedOrder, orderHashes, orderHash, 0
+            );
+
             _updateStatus(orderHash, fillNumerator, fillDenominator, true);
         } else {
             // Return the generated order based on the order params and the

--- a/src/core/lib/OrderFulfiller.sol
+++ b/src/core/lib/OrderFulfiller.sol
@@ -119,11 +119,13 @@ contract OrderFulfiller is
             recipient
         );
 
-        bytes32[] memory orderHashes = new bytes32[](0);
+        // Declare empty bytes32 array and populate with the order hash.
+        bytes32[] memory orderHashes = new bytes32[](1);
+        orderHashes[0] = orderHash;
 
         if (advancedOrder.parameters.orderType != OrderType.CONTRACT) {
             _assertRestrictedAdvancedOrderAuthorization(
-                advancedOrder, orderHashes, orderHash, 0
+                advancedOrders[0], orderHashes, orderHash, 0
             );
 
             _updateStatus(orderHash, fillNumerator, fillDenominator, true);
@@ -192,10 +194,6 @@ contract OrderFulfiller is
         }
 
         _transferEach(orderParameters, fulfillerConduitKey);
-
-        // Declare empty bytes32 array and populate with the order hash.
-        orderHashes = new bytes32[](1);
-        orderHashes[0] = orderHash;
 
         // Ensure restricted orders have a valid submitter or pass a zone check.
         _assertRestrictedAdvancedOrderValidity(

--- a/src/types/lib/ConsiderationConstants.sol
+++ b/src/types/lib/ConsiderationConstants.sol
@@ -108,7 +108,7 @@ uint256 constant OrderParameters_consideration_head_offset = 0x60;
 uint256 constant OrderParameters_startTime_offset = 0xa0;
 uint256 constant OrderParameters_endTime_offset = 0xc0;
 uint256 constant OrderParameters_zoneHash_offset = 0xe0;
-// uint256 constant OrderParameters_salt_offset = 0x100;
+uint256 constant OrderParameters_salt_offset = 0x100;
 uint256 constant OrderParameters_conduit_offset = 0x120;
 uint256 constant OrderParameters_counter_offset = 0x140;
 
@@ -524,7 +524,7 @@ uint256 constant ZoneParameters_endTime_offset = 0x100;
 uint256 constant ZoneParameters_zoneHash_offset = 0x120;
 uint256 constant ZoneParameters_base_tail_offset = 0x140;
 uint256 constant ZoneParameters_selectorAndPointer_length = 0x24;
-uint256 constant ZoneParameters_basicOrderFixedElements_length = 0x64;
+uint256 constant ZoneParameters_basicOrderFixedElements_length = 0x44;
 
 // ConsiderationDecoder Constants
 uint256 constant OrderParameters_head_size = 0x0160;


### PR DESCRIPTION
Also leverages fixed calldata offsets throughout basic fulfillment, letting us do away with the default decoder and the named `parameters` argument (this was necessary to deal with stack depth issues, but should speed things up on those routes)