### PR TITLE
add auth calldata hashing to moat

### DIFF
--- a/test/foundry/new/FuzzEngine.t.sol
+++ b/test/foundry/new/FuzzEngine.t.sol
@@ -1464,8 +1464,8 @@ contract FuzzEngineTest is FuzzEngine {
             considerationComponents
         ).withChecks(checks).withMaximumFulfilled(2);
 
-        context.expectations.expectedZoneCalldataHash = advancedOrders
-            .getExpectedZoneCalldataHash(
+        context.expectations.expectedZoneValidateCalldataHashes = advancedOrders
+            .getExpectedZoneValidateCalldataHash(
             address(getSeaport()),
             address(this),
             new CriteriaResolver[](0),

--- a/test/foundry/new/helpers/DebugUtil.sol
+++ b/test/foundry/new/helpers/DebugUtil.sol
@@ -42,7 +42,8 @@ struct ContextOutputSelection {
     bool basicOrderParameters;
     bool testHelpers;
     bool checks;
-    bool expectedZoneCalldataHash;
+    bool expectedZoneAuthorizeCalldataHashes;
+    bool expectedZoneValidateCalldataHashes;
     bool expectedContractOrderCalldataHashes;
     bool expectedResults;
     bool expectedImplicitExecutions;
@@ -216,11 +217,11 @@ function dumpContext(
             cast(context.executionState.preExecOrderStatuses)
         );
     }
-    // if (outputSelection.expectedZoneCalldataHash) {
+    // if (outputSelection.expectedZoneValidateCalldataHash) {
     //     jsonOut = Searializer.tojsonDynArrayBytes32(
     //         "root",
-    //         "expectedZoneCalldataHash",
-    //         context.expectations.expectedZoneCalldataHash
+    //         "expectedZoneValidateCalldataHash",
+    //         context.expectations.expectedZoneValidateCalldataHash
     //     );
     // }
     // if (outputSelection.expectedContractOrderCalldataHashes) {

--- a/test/foundry/new/helpers/FuzzChecks.sol
+++ b/test/foundry/new/helpers/FuzzChecks.sol
@@ -113,6 +113,52 @@ abstract contract FuzzChecks is Test {
         }
     }
 
+     /**
+     * @dev Check that the zone is getting the right calldata in authorizeOrder.
+     *
+     * @param context A Fuzz test context.
+     */
+    function check_authorizeOrderExpectedDataHash(FuzzTestContext memory context)
+        public
+    {
+        // Iterate over the orders.
+        for (uint256 i; i < context.executionState.orders.length; i++) {
+            OrderParameters memory order =
+                context.executionState.orders[i].parameters;
+
+
+            // If the order is restricted, check the calldata.
+            if (
+                order.orderType == OrderType.FULL_RESTRICTED
+                    || order.orderType == OrderType.PARTIAL_RESTRICTED
+            ) {
+                testZone = payable(order.zone);
+
+                // Each order has a calldata hash, indexed to orders, that is
+                // expected to be returned by the zone.
+                bytes32 expectedCalldataHash =
+                    context.expectations.expectedZoneAuthorizeCalldataHashes[i];
+
+                bytes32 orderHash =
+                    context.executionState.orderDetails[i].orderHash;
+
+                // Use order hash to get the expected calldata hash from zone.
+                // TODO: fix this in cases where contract orders are part of
+                // orderHashes (the hash calculation is most likely incorrect).
+                bytes32 actualCalldataHash = HashValidationZoneOfferer(testZone)
+                    .orderHashToAuthorizeOrderDataHash(orderHash);
+
+                // Check that the expected calldata hash matches the actual
+                // calldata hash.
+                assertEq(
+                    actualCalldataHash,
+                    expectedCalldataHash,
+                    "check_authorizeOrderExpectedDataHash: actualCalldataHash != expectedCalldataHash"
+                );
+            }
+        }
+    }
+
     /**
      * @dev Check that the zone is getting the right calldata.
      *
@@ -136,7 +182,7 @@ abstract contract FuzzChecks is Test {
                 // Each order has a calldata hash, indexed to orders, that is
                 // expected to be returned by the zone.
                 bytes32 expectedCalldataHash =
-                    context.expectations.expectedZoneCalldataHash[i];
+                    context.expectations.expectedZoneValidateCalldataHashes[i];
 
                 bytes32 orderHash =
                     context.executionState.orderDetails[i].orderHash;

--- a/test/foundry/new/helpers/FuzzHelpers.sol
+++ b/test/foundry/new/helpers/FuzzHelpers.sol
@@ -734,6 +734,46 @@ library FuzzHelpers {
 
     /**
      * @dev Derive ZoneParameters from a given restricted order and return
+     *      the expected calldata hash for the call to authorizeOrder.
+     *
+     * @param orders             The restricted orders.
+     * @param seaport            The Seaport address.
+     * @param fulfiller          The fulfiller.
+     * @param maximumFulfilled   The maximum number of orders to fulfill.
+     * @param criteriaResolvers  The criteria resolvers.
+     * @param maximumFulfilled   The maximum number of orders to fulfill.
+     * @param unavailableReasons The availability status.
+     *
+     * @return calldataHashes The derived calldata hashes.
+     */
+    function getExpectedZoneAuthorizeCalldataHash(
+        AdvancedOrder[] memory orders,
+        address seaport,
+        address fulfiller,
+        CriteriaResolver[] memory criteriaResolvers,
+        uint256 maximumFulfilled,
+        UnavailableReason[] memory unavailableReasons
+    ) internal view returns (bytes32[] memory calldataHashes) {
+        calldataHashes = new bytes32[](orders.length);
+
+        ZoneParameters[] memory zoneParameters = orders.getZoneAuthorizeParameters(
+            fulfiller,
+            maximumFulfilled,
+            seaport,
+            criteriaResolvers,
+            unavailableReasons
+        );
+
+        for (uint256 i; i < zoneParameters.length; ++i) {
+            // Derive the expected calldata hash for the call to authorizeOrder
+            calldataHashes[i] = keccak256(
+                abi.encodeCall(ZoneInterface.authorizeOrder, (zoneParameters[i]))
+            );
+        }
+    }
+
+    /**
+     * @dev Derive ZoneParameters from a given restricted order and return
      *      the expected calldata hash for the call to validateOrder.
      *
      * @param orders             The restricted orders.
@@ -746,7 +786,7 @@ library FuzzHelpers {
      *
      * @return calldataHashes The derived calldata hashes.
      */
-    function getExpectedZoneCalldataHash(
+    function getExpectedZoneValidateCalldataHash(
         AdvancedOrder[] memory orders,
         address seaport,
         address fulfiller,
@@ -756,7 +796,7 @@ library FuzzHelpers {
     ) internal view returns (bytes32[] memory calldataHashes) {
         calldataHashes = new bytes32[](orders.length);
 
-        ZoneParameters[] memory zoneParameters = orders.getZoneParameters(
+        ZoneParameters[] memory zoneParameters = orders.getZoneValidateParameters(
             fulfiller,
             maximumFulfilled,
             seaport,

--- a/test/foundry/new/helpers/FuzzSetup.sol
+++ b/test/foundry/new/helpers/FuzzSetup.sol
@@ -194,10 +194,10 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
         }
 
         // Get the expected zone calldata hashes for each order.
-        bytes32[] memory calldataHashes = context
+        bytes32[] memory authorizeCalldataHashes = context
             .executionState
             .orders
-            .getExpectedZoneCalldataHash(
+            .getExpectedZoneAuthorizeCalldataHash(
             address(context.seaport),
             context.executionState.caller,
             context.executionState.criteriaResolvers,
@@ -205,8 +205,22 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
             unavailableReasons
         );
 
-        // Provision the expected zone calldata hash array.
-        bytes32[] memory expectedZoneCalldataHash = new bytes32[](
+        bytes32[] memory validateCalldataHashes = context
+            .executionState
+            .orders
+            .getExpectedZoneValidateCalldataHash(
+            address(context.seaport),
+            context.executionState.caller,
+            context.executionState.criteriaResolvers,
+            context.executionState.maximumFulfilled,
+            unavailableReasons
+        );
+
+        // Provision the expected zone calldata hash arrays.
+        bytes32[] memory expectedZoneAuthorizeCalldataHashes = new bytes32[](
+            context.executionState.orders.length
+        );
+        bytes32[] memory expectedZoneValidateCalldataHashes = new bytes32[](
             context.executionState.orders.length
         );
 
@@ -227,13 +241,18 @@ abstract contract FuzzSetup is Test, AmountDeriverHelper {
                     )
             ) {
                 registerChecks = true;
-                expectedZoneCalldataHash[i] = calldataHashes[i];
+                expectedZoneAuthorizeCalldataHashes[i] = authorizeCalldataHashes[i];
+                expectedZoneValidateCalldataHashes[i] = validateCalldataHashes[i];
             }
         }
 
-        context.expectations.expectedZoneCalldataHash = expectedZoneCalldataHash;
+        context.expectations.expectedZoneAuthorizeCalldataHashes = expectedZoneAuthorizeCalldataHashes;
+        context.expectations.expectedZoneValidateCalldataHashes = expectedZoneValidateCalldataHashes;
 
         if (registerChecks) {
+            context.registerCheck(
+                FuzzChecks.check_authorizeOrderExpectedDataHash.selector
+            );
             context.registerCheck(
                 FuzzChecks.check_validateOrderExpectedDataHash.selector
             );

--- a/test/foundry/new/helpers/FuzzTestContextLib.sol
+++ b/test/foundry/new/helpers/FuzzTestContextLib.sol
@@ -140,7 +140,8 @@ struct Expectations {
     /**
      * @dev Expected zone calldata hashes.
      */
-    bytes32[] expectedZoneCalldataHash;
+    bytes32[] expectedZoneAuthorizeCalldataHashes;
+    bytes32[] expectedZoneValidateCalldataHashes;
     /**
      * @dev Expected contract order calldata hashes. Index 0 of the outer array
      *      corresponds to the generateOrder hash, while index 1 corresponds to
@@ -392,10 +393,35 @@ library FuzzTestContextLib {
         Result[] memory results;
         bool[] memory available;
         Execution[] memory executions;
-        bytes32[] memory hashes;
-        bytes32[] memory expectedTransferEventHashes;
-        bytes32[] memory expectedSeaportEventHashes;
         Vm.Log[] memory actualEvents;
+        Expectations memory expectations;
+
+        {
+            bytes32[] memory authorizeHashes;
+            bytes32[] memory validateHashes;
+            bytes32[] memory expectedTransferEventHashes;
+            bytes32[] memory expectedSeaportEventHashes;
+
+            expectations = Expectations({
+                expectedZoneAuthorizeCalldataHashes: authorizeHashes,
+                expectedZoneValidateCalldataHashes: validateHashes,
+                expectedContractOrderCalldataHashes: new bytes32[2][](0),
+                expectedImplicitPreExecutions: new Execution[](0),
+                expectedImplicitPostExecutions: new Execution[](0),
+                expectedExplicitExecutions: new Execution[](0),
+                allExpectedExecutions: new Execution[](0),
+                expectedResults: results,
+                // expectedAvailableOrders: new bool[](0),
+                expectedTransferEventHashes: expectedTransferEventHashes,
+                expectedSeaportEventHashes: expectedSeaportEventHashes,
+                ineligibleOrders: new bool[](orders.length),
+                ineligibleFailures: new bool[](uint256(Failure.length)),
+                expectedImpliedNativeExecutions: 0,
+                expectedNativeTokensReturned: 0,
+                minimumValue: 0,
+                expectedFillFractions: new FractionResults[](orders.length)
+            });
+        }
 
         return FuzzTestContext({
             _action: bytes4(0),
@@ -419,24 +445,7 @@ library FuzzTestContextLib {
                 availableOrders: available,
                 executions: executions
             }),
-            expectations: Expectations({
-                expectedZoneCalldataHash: hashes,
-                expectedContractOrderCalldataHashes: new bytes32[2][](0),
-                expectedImplicitPreExecutions: new Execution[](0),
-                expectedImplicitPostExecutions: new Execution[](0),
-                expectedExplicitExecutions: new Execution[](0),
-                allExpectedExecutions: new Execution[](0),
-                expectedResults: results,
-                // expectedAvailableOrders: new bool[](0),
-                expectedTransferEventHashes: expectedTransferEventHashes,
-                expectedSeaportEventHashes: expectedSeaportEventHashes,
-                ineligibleOrders: new bool[](orders.length),
-                ineligibleFailures: new bool[](uint256(Failure.length)),
-                expectedImpliedNativeExecutions: 0,
-                expectedNativeTokensReturned: 0,
-                minimumValue: 0,
-                expectedFillFractions: new FractionResults[](orders.length)
-            }),
+            expectations: expectations,
             executionState: ExecutionState({
                 caller: address(0),
                 contractOffererNonce: 0,

--- a/test/foundry/new/helpers/Searializer.sol
+++ b/test/foundry/new/helpers/Searializer.sol
@@ -677,8 +677,13 @@ library Searializer {
         tojsonDynArrayBytes4(obj, "checks", value.checks);
         tojsonDynArrayBytes32(
             obj,
-            "expectedZoneCalldataHash",
-            value.expectations.expectedZoneCalldataHash
+            "expectedZoneAuthorizeCalldataHashes",
+            value.expectations.expectedZoneAuthorizeCalldataHashes
+        );
+        tojsonDynArrayBytes32(
+            obj,
+            "expectedZoneValidateCalldataHashes",
+            value.expectations.expectedZoneValidateCalldataHashes
         );
         tojsonDynArrayArray2Bytes32(
             obj,

--- a/test/foundry/zone/impl/HashCalldataTestZone.sol
+++ b/test/foundry/zone/impl/HashCalldataTestZone.sol
@@ -62,15 +62,15 @@ contract HashCalldataTestZone is ZoneInterface {
     }
 
     function setExpectedAuthorizeCalldataHash(
-        bytes32 _expectedZoneCalldataHash
+        bytes32 _expectedZoneAuthorizeCalldataHash
     ) public {
-        expectedZoneAuthorizeCalldataHash = _expectedZoneCalldataHash;
+        expectedZoneAuthorizeCalldataHash = _expectedZoneAuthorizeCalldataHash;
     }
 
     function setExpectedValidateCalldataHash(
-        bytes32 _expectedZoneCalldataHash
+        bytes32 _expectedZoneValidateCalldataHash
     ) public {
-        expectedZoneValidateCalldataHash = _expectedZoneCalldataHash;
+        expectedZoneValidateCalldataHash = _expectedZoneValidateCalldataHash;
     }
 
     receive() external payable { }


### PR DESCRIPTION
## Motivation

Want to start getting MOAT more aware of auth.

## Solution

Add parallel calldata hashing for auth calls.
