### PR TITLE
remove unused errors

### DIFF
--- a/src/types/lib/ConsiderationErrors.sol
+++ b/src/types/lib/ConsiderationErrors.sol
@@ -379,38 +379,6 @@ function _revertInvalidTime(uint256 startTime, uint256 endTime) pure {
 }
 
 /**
- * @dev Reverts execution with a
- *      "MismatchedFulfillmentOfferAndConsiderationComponents" error message.
- *
- * @param fulfillmentIndex         The index of the fulfillment that caused the
- *                                 error.
- */
-function _revertMismatchedFulfillmentOfferAndConsiderationComponents(
-    uint256 fulfillmentIndex
-) pure {
-    assembly {
-        // Store left-padded selector with push4 (reduces bytecode),
-        // mem[28:32] = selector
-        mstore(0, MismatchedOfferAndConsiderationComponents_error_selector)
-
-        // Store fulfillment index argument.
-        mstore(
-            MismatchedOfferAndConsiderationComponents_error_idx_ptr,
-            fulfillmentIndex
-        )
-
-        // revert(abi.encodeWithSignature(
-        //     "MismatchedFulfillmentOfferAndConsiderationComponents(uint256)",
-        //     fulfillmentIndex
-        // ))
-        revert(
-            Error_selector_offset,
-            MismatchedOfferAndConsiderationComponents_error_length
-        )
-    }
-}
-
-/**
  * @dev Reverts execution with a "MissingFulfillmentComponentOnAggregation"
  *       error message.
  *
@@ -483,26 +451,6 @@ function _revertNoSpecifiedOrdersAvailable() pure {
 
         // revert(abi.encodeWithSignature("NoSpecifiedOrdersAvailable()"))
         revert(Error_selector_offset, NoSpecifiedOrdersAvailable_error_length)
-    }
-}
-
-/**
- * @dev Reverts execution with a "OfferAndConsiderationRequiredOnFulfillment"
- *      error message.
- */
-function _revertOfferAndConsiderationRequiredOnFulfillment() pure {
-    assembly {
-        // Store left-padded selector with push4 (reduces bytecode),
-        // mem[28:32] = selector
-        mstore(0, OfferAndConsiderationRequiredOnFulfillment_error_selector)
-
-        // revert(abi.encodeWithSignature(
-        //     "OfferAndConsiderationRequiredOnFulfillment()"
-        // ))
-        revert(
-            Error_selector_offset,
-            OfferAndConsiderationRequiredOnFulfillment_error_length
-        )
     }
 }
 
@@ -613,61 +561,6 @@ function _revertPartialFillsNotEnabledForOrder() pure {
         revert(
             Error_selector_offset, PartialFillsNotEnabledForOrder_error_length
         )
-    }
-}
-
-/**
- * @dev Reverts execution with an "UnresolvedConsiderationCriteria" error
- *      message.
- */
-function _revertUnresolvedConsiderationCriteria(
-    uint256 orderIndex,
-    uint256 considerationIndex
-) pure {
-    assembly {
-        // Store left-padded selector with push4 (reduces bytecode),
-        // mem[28:32] = selector
-        mstore(0, UnresolvedConsiderationCriteria_error_selector)
-
-        // Store orderIndex and considerationIndex arguments.
-        mstore(UnresolvedConsiderationCriteria_error_orderIndex_ptr, orderIndex)
-        mstore(
-            UnresolvedConsiderationCriteria_error_considerationIdx_ptr,
-            considerationIndex
-        )
-
-        // revert(abi.encodeWithSignature(
-        //     "UnresolvedConsiderationCriteria(uint256, uint256)",
-        //     orderIndex,
-        //     considerationIndex
-        // ))
-        revert(
-            Error_selector_offset, UnresolvedConsiderationCriteria_error_length
-        )
-    }
-}
-
-/**
- * @dev Reverts execution with an "UnresolvedOfferCriteria" error message.
- */
-function _revertUnresolvedOfferCriteria(uint256 orderIndex, uint256 offerIndex)
-    pure
-{
-    assembly {
-        // Store left-padded selector with push4 (reduces bytecode),
-        // mem[28:32] = selector
-        mstore(0, UnresolvedOfferCriteria_error_selector)
-
-        // Store arguments.
-        mstore(UnresolvedOfferCriteria_error_orderIndex_ptr, orderIndex)
-        mstore(UnresolvedOfferCriteria_error_offerIndex_ptr, offerIndex)
-
-        // revert(abi.encodeWithSignature(
-        //     "UnresolvedOfferCriteria(uint256, uint256)",
-        //     orderIndex,
-        //     offerIndex
-        // ))
-        revert(Error_selector_offset, UnresolvedOfferCriteria_error_length)
     }
 }
 

--- a/test/foundry/ConsiderationErrors.t.sol
+++ b/test/foundry/ConsiderationErrors.t.sol
@@ -106,18 +106,6 @@ contract ConsiderationErrors is BaseOrderTest, ConsiderationErrorsWrapper {
         this.__revertInvalidTime(6, 7);
     }
 
-    function test_revertMismatchedFulfillmentOfferAndConsiderationComponents()
-        public
-    {
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "MismatchedFulfillmentOfferAndConsiderationComponents(uint256)",
-                8
-            )
-        );
-        this.__revertMismatchedFulfillmentOfferAndConsiderationComponents(8);
-    }
-
     function test_revertMissingOriginalConsiderationItems() public {
         vm.expectRevert(
             abi.encodeWithSignature("MissingOriginalConsiderationItems()")
@@ -133,15 +121,6 @@ contract ConsiderationErrors is BaseOrderTest, ConsiderationErrorsWrapper {
     function test_revertNoSpecifiedOrdersAvailable() public {
         vm.expectRevert(abi.encodeWithSignature("NoSpecifiedOrdersAvailable()"));
         this.__revertNoSpecifiedOrdersAvailable();
-    }
-
-    function test_revertOfferAndConsiderationRequiredOnFulfillment() public {
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "OfferAndConsiderationRequiredOnFulfillment()"
-            )
-        );
-        this.__revertOfferAndConsiderationRequiredOnFulfillment();
     }
 
     function test_revertOrderAlreadyFilled() public {
@@ -181,24 +160,6 @@ contract ConsiderationErrors is BaseOrderTest, ConsiderationErrorsWrapper {
             abi.encodeWithSignature("PartialFillsNotEnabledForOrder()")
         );
         this.__revertPartialFillsNotEnabledForOrder();
-    }
-
-    function test_revertUnresolvedConsiderationCriteria() public {
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "UnresolvedConsiderationCriteria(uint256,uint256)", 9, 10
-            )
-        );
-        this.__revertUnresolvedConsiderationCriteria(9, 10);
-    }
-
-    function test_revertUnresolvedOfferCriteria() public {
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "UnresolvedOfferCriteria(uint256,uint256)", 11, 12
-            )
-        );
-        this.__revertUnresolvedOfferCriteria(11, 12);
     }
 
     function test_revertUnusedItemParameters() public {

--- a/test/foundry/utils/ConsiderationErrorsWrapper.sol
+++ b/test/foundry/utils/ConsiderationErrorsWrapper.sol
@@ -18,19 +18,15 @@ import {
     _revertInvalidNativeOfferItem,
     _revertInvalidProof,
     _revertInvalidTime,
-    _revertMismatchedFulfillmentOfferAndConsiderationComponents,
     _revertMissingFulfillmentComponentOnAggregation,
     _revertMissingOriginalConsiderationItems,
     _revertNoReentrantCalls,
     _revertNoSpecifiedOrdersAvailable,
-    _revertOfferAndConsiderationRequiredOnFulfillment,
     _revertOrderAlreadyFilled,
     _revertOrderCriteriaResolverOutOfRange,
     _revertOrderIsCancelled,
     _revertOrderPartiallyFilled,
     _revertPartialFillsNotEnabledForOrder,
-    _revertUnresolvedConsiderationCriteria,
-    _revertUnresolvedOfferCriteria,
     _revertUnusedItemParameters
 } from "seaport-types/src/lib/ConsiderationErrors.sol";
 
@@ -177,21 +173,6 @@ contract ConsiderationErrorsWrapper {
     }
 
     /**
-     * @dev Reverts execution with a
-     *      "MismatchedFulfillmentOfferAndConsiderationComponents" error message.
-     *
-     * @param fulfillmentIndex         The index of the fulfillment that caused the
-     *                                 error.
-     */
-    function __revertMismatchedFulfillmentOfferAndConsiderationComponents(
-        uint256 fulfillmentIndex
-    ) external pure {
-        _revertMismatchedFulfillmentOfferAndConsiderationComponents(
-            fulfillmentIndex
-        );
-    }
-
-    /**
      * @dev Reverts execution with a "MissingFulfillmentComponentOnAggregation"
      *       error message.
      *
@@ -226,17 +207,6 @@ contract ConsiderationErrorsWrapper {
      */
     function __revertNoSpecifiedOrdersAvailable() external pure {
         _revertNoSpecifiedOrdersAvailable();
-    }
-
-    /**
-     * @dev Reverts execution with a "OfferAndConsiderationRequiredOnFulfillment"
-     *      error message.
-     */
-    function __revertOfferAndConsiderationRequiredOnFulfillment()
-        external
-        pure
-    {
-        _revertOfferAndConsiderationRequiredOnFulfillment();
     }
 
     /**
@@ -284,27 +254,6 @@ contract ConsiderationErrorsWrapper {
      */
     function __revertPartialFillsNotEnabledForOrder() external pure {
         _revertPartialFillsNotEnabledForOrder();
-    }
-
-    /**
-     * @dev Reverts execution with an "UnresolvedConsiderationCriteria" error
-     *      message.
-     */
-    function __revertUnresolvedConsiderationCriteria(
-        uint256 orderIndex,
-        uint256 considerationIndex
-    ) external pure {
-        _revertUnresolvedConsiderationCriteria(orderIndex, considerationIndex);
-    }
-
-    /**
-     * @dev Reverts execution with an "UnresolvedOfferCriteria" error message.
-     */
-    function __revertUnresolvedOfferCriteria(
-        uint256 orderIndex,
-        uint256 offerIndex
-    ) external pure {
-        _revertUnresolvedOfferCriteria(orderIndex, offerIndex);
     }
 
     /**


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Some errors have gone unused

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Remove unused errors. Since Solidity LSP barely works, I grabbed all exported symbols from both ConsiderationErors and ConsiderationErrorConstants ASTs and checked they were used >2 times in all imported files (once for import, once in actual code body).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
