### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Seaport 1.6 Development Repo
 
-Welcome to the home of Seaport 1.6 development. For the most part, it's safe to treat this repo like you'd treat [Seaport](https://github.com/ProjectOpenSea/seaport). The documentation found there will substantialy serve for this repo.
+Welcome to the home of Seaport 1.6 development. For the most part, it's safe to treat this repo like you'd treat [Seaport](https://github.com/ProjectOpenSea/seaport). The documentation found there will substantially serve for this repo.
 
 ### Structure
 
 The [`./src`](./src) directory is broken up into [`/core`](./src/core), [`/main`](./src/main), [`/sol`](./src/sol), and [`/types`](./src/types), which closely correspond to the [seaport-core](https://github.com/ProjectOpenSea/seaport-core), ["main"](https://github.com/ProjectOpenSea/seaport), [seaport-sol](https://github.com/ProjectOpenSea/seaport-sol), and [seaport-types](https://github.com/ProjectOpenSea/seaport-types) repos, respectively.
 
-The remappings in the [foundry.toml](./foundry.toml) file are configured to use the same import style found in the production repos (e.g. `from "seaport-types/src/..."`), but instead of pointing to a dependency in `./lib`, they point to some portion of `./src`.  The idea is to duplicate the experience of working in [Seaport](https://github.com/ProjectOpenSea/seaport), but without the headache of keeping cross-repo changes synced. The tradeoff is that comile times will be longer, but the intial experience of working across multiple repos and fighting git submodules strongly suggested that this approach is preferable.
+The remappings in the [foundry.toml](./foundry.toml) file are configured to use the same import style found in the production repos (e.g. `from "seaport-types/src/..."`), but instead of pointing to a dependency in `./lib`, they point to some portion of `./src`.  The idea is to duplicate the experience of working in [Seaport](https://github.com/ProjectOpenSea/seaport), but without the headache of keeping cross-repo changes synced. The tradeoff is that compile times will be longer, but the initial experience of working across multiple repos and fighting git submodules strongly suggested that this approach is preferable.
 
 When 1.6 is ready, we'll create 1.6 branches on all of the seaport repos and move the changes over from this repo to those repos.
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This pull request fixes minor typos in the README to improve clarity and professionalism:
- "substantialy" → "substantially"
- "comile" → "compile"
- "intial" → "initial"

These changes enhance the documentation quality and readability for contributors and users alike.

Hi @DJViau, I noticed your contributions to this repository. I'd love to chat with you about your work on the Deadpool NFT you helped create in 2019. This is the only way I've figured out how to directly contact you. If you're willing, you can contact me via [GitHub Discussions](https://github.com/eltonjock/seaport-1.6/discussions). I know this is unorthodox but hopefully my tiny contribution to fixing some typos makes up for it.

## Solution

The README has been updated with the corrected spelling. No code changes were required.
